### PR TITLE
Fix connector table heading layout

### DIFF
--- a/chapters/ProductDescription.tex
+++ b/chapters/ProductDescription.tex
@@ -60,7 +60,8 @@ NEXT-MS & \ReplicaNextLong{} self-assembly kit with a single connector. \\
     \caption{Connector layout for dual-connector \ReplicaGenOne{} dashboards.}
 \end{figure}
 
-\paragraph{White connector}
+\noindent\textbf{White connector}
+
 {\scriptsize
 \begin{tblr}{
     colspec={Q[l,1.4cm] X[l]},
@@ -82,7 +83,8 @@ NEXT-MS & \ReplicaNextLong{} self-assembly kit with a single connector. \\
 13 & KL~56a high-beam indicator input (+12~V active). \\
 \end{tblr}}
 
-\paragraph{Black connector}
+\noindent\textbf{Black connector}
+
 {\scriptsize
 \begin{tblr}{
     colspec={Q[l,1.4cm] X[l]},


### PR DESCRIPTION
## Summary
- ensure the "White connector" heading breaks before its pinout table so the layout wraps correctly
- ensure the "Black connector" heading breaks before its pinout table for consistent formatting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1162e78808323b8bf9c1d59292b1e