### PR TITLE
Update title page layout and metadata

### DIFF
--- a/frontmatter/information.tex
+++ b/frontmatter/information.tex
@@ -19,8 +19,8 @@
     }
     \textsf{\textcolor{Gray40}{Title}}          & \ManualTitle                           \\
     \textsf{\textcolor{Gray40}{Author}}         & \ManualAuthor                          \\
-    \textsf{\textcolor{Gray40}{\DivisionType{}}} & \Division                                \\
-    \textsf{\textcolor{Gray40}{Maintainer}}     & \Maintainer{} --- \MaintainersDivision \\
+    % \textsf{\textcolor{Gray40}{\DivisionType{}}} & \Division                                \\
+    % \textsf{\textcolor{Gray40}{Maintainer}}     & \Maintainer{} --- \MaintainersDivision \\
     % \textsf{\textcolor{Gray40}{Abstract}}      & \ManualAbstract                          \\
     \textsf{\textcolor{Gray40}{Keywords}}       & \ManualKeywords                          \\
 \end{tblr}}

--- a/frontmatter/title.tex
+++ b/frontmatter/title.tex
@@ -1,19 +1,20 @@
 \pdfbookmark{Title Page}{titlepage} % add PDF outline entry
 \thispagestyle{empty} % no number on the title page
 \begin{center}
+    \Large
+
+    \vspace{-1.5em}
+
+    {\ifFANCY\sffamily\Huge\else\bfseries\LARGE\fi
+        \MakeUppercase{User Manual} \par}
+
+    \vspace{1.5em}
+
     \begin{adjustbox}{center,trim=0 0 0 0}
         \includegraphics[width=0.72\textwidth]{digifiz_manual/image003.jpg}
     \end{adjustbox}
 
-    \Large
-
-    \vspace{-1.5em}
-    \vfill
-
-    {\ifFANCY\sffamily\Huge\else\bfseries\LARGE\fi
-        \MakeUppercase{\ManualDocumentType} USER MANUAL}
-
-    \vfill
+    \vspace{1.5em}
 
     {\Huge
         \ManualAuthor}
@@ -23,17 +24,13 @@
     {\fontsize{30pt}{36pt}\selectfont \bfseries
         \ManualTitleFront \par}
 
-    \vfill
-
-    \Division
-
     \vspace{1.1em}
 
     \begin{center}
         \large
         \renewcommand{\arraystretch}{1.2}
         \begin{tabular}{>{\sffamily\color{Gray40}}r @{\hspace{1.0em}} l}
-            Manual Maintainer    & \Maintainer     \\
+            % Manual Maintainer    & \Maintainer     \\
             \ifdef{\ProductLine}{%
             Product Line         & \ProductLine \\
             }{}

--- a/preamble/data.tex
+++ b/preamble/data.tex
@@ -18,12 +18,12 @@
 }
 
 %% Author credited for the manual
-\newcommand*{\ManualAuthor}{Digifiz Replica Project Team}
+\newcommand*{\ManualAuthor}{Digifiz Replica Project Team - PHOL LABS Kft}
 %% Plaintext version for PDF metadata, uncomment if needed (defaults to \ManualAuthor)
-\newcommand*{\ManualAuthorPlaintext}{Digifiz Replica Project Team}
+\newcommand*{\ManualAuthorPlaintext}{Digifiz Replica Project Team - PHOL LABS Kft}
 
 %% Year when the manual is released
-\newcommand*{\YearReleased}{2024}
+\newcommand*{\YearReleased}{\the\year}
 %% Year of the last revision, uncomment if it is different from \YearReleased
 % \newcommand*{\YearRevised}{2025}
 
@@ -31,7 +31,7 @@
 \newcommand*{\Organization}{PHOL-LABS Kft}
 
 %% Division or team responsible for the manual
-\newcommand*{\Division}{Digifiz Replica Engineering}
+\newcommand*{\Division}{}
 
 %% Division type (department, institute, team, ...)
 \newcommand*{\DivisionType}{Team}
@@ -42,10 +42,10 @@
 % \newcommand*{\CoMaintainer}{Name, Surname, and Titles}
 
 %% Maintainer's division/team information
-\newcommand*{\MaintainersDivision}{Digifiz Replica Engineering}
+\newcommand*{\MaintainersDivision}{}
 
 %% Product line or program this manual covers
-\newcommand*{\ProductLine}{Digifiz Replica Instrument Clusters}
+\newcommand*{\ProductLine}{Volkswagen Golf®, Jetta I, II}
 
 %% Abstract (recommended length around 80-200 words)
 \newcommand*{\ManualAbstract}{%


### PR DESCRIPTION
## Summary
- move the user manual heading to the top of the title page and suppress the division and maintainer rows
- update the credited author, product line text, and release year metadata

## Testing
- latexmk -pdf DR_DRNext_User_Manual_mk1_mk2.tex *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d1171fa264832390e153460b7e9d0a