### PR TITLE
Fix speed coefficient adjustment description

### DIFF
--- a/chapters/ReplicaNextMaintenance.tex
+++ b/chapters/ReplicaNextMaintenance.tex
@@ -150,7 +150,7 @@ The \emph{Control} tab provides a command input line (1), a \emph{Process} butto
 \end{table}
 
 \section{Reading parameters and examples}
-To read a parameter, add 128 to the command number (for example, \verb|129 0| reports the speed coefficient). Typical commands include disabling automatic brightness (\verb|13 0|), enabling it again (\verb|13 1|), adjusting the speed coefficient (\verb|1 110| increases the displayed speed by roughly 5\%), and setting the odometer (\verb|11 123456|). Clock values are set with \verb|255 <hours>| followed by \verb|254 <minutes>|. Commands 31--33 set the RGB components of the user interface colour.
+To read a parameter, add 128 to the command number (for example, \verb|129 0| reports the speed coefficient). Typical commands include disabling automatic brightness (\verb|13 0|), enabling it again (\verb|13 1|), adjusting the speed coefficient (\verb|1 110| increases the displayed speed by 10\%), and setting the odometer (\verb|11 123456|). Clock values are set with \verb|255 <hours>| followed by \verb|254 <minutes>|. Commands 31--33 set the RGB components of the user interface colour.
 
 \section{Service commands}
 Recent firmware revisions accept human-readable parameter names, for example \verb|PARAMETER_RPMCOEFFICIENT 3000|. The diagnostic command \verb|adc 0| prints raw ADC readings for sensor troubleshooting. Firmware updates add visual colour controls, so update regularly through the \emph{WiFi} tab to access the latest features.


### PR DESCRIPTION
## Summary
- correct the Replica Next maintenance instructions to note that setting `1 110` increases speed by 10%

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d117b8c4348323b590b754a9d06e1f