### PR TITLE
Format manual URLs on dedicated lines

### DIFF
--- a/chapters/Precautions.tex
+++ b/chapters/Precautions.tex
@@ -11,7 +11,8 @@ This chapter consolidates the mandatory safety rules that accompany every \Repli
     \item \textbf{Beware of resonances in cable-driven speedometers.} Mechanical drives often oscillate at 40--60~km/h. Fit the supplied electronic sensor---it ships with all current Gen~1.5 and Gen~2 kits---whenever possible.
     \item \textbf{Plan external MFA controls for Generation~2 dashboards.} The VW badge touch sensor was removed, so MFA mode switching must come from the steering-column stalk or another external switch.
     \item \textbf{Account for the standby current.} A Generation~2 cluster draws roughly 11--13~mA from the vehicle battery even when the ignition is off. This quiescent consumption cannot be reduced.
-    \item \textbf{Instantaneous fuel consumption is not factory fitted.} The feature can be retrofitted to Gen~1 and Gen~1.5 units following the instructions at\newline\url{https://www.youtube.com/watch?v=qWqvYc9388U}, but it has not been validated for Gen~2 hardware.
+    \item \textbf{Instantaneous fuel consumption is not factory fitted.} The feature can be retrofitted to Gen~1 and Gen~1.5 units following the instructions below, but it has not been validated for Gen~2 hardware.
+        \displayurl{https://www.youtube.com/watch?v=qWqvYc9388U}
 \end{enumerate}
 
 \begin{figure}[htbp]

--- a/chapters/ProductDescription.tex
+++ b/chapters/ProductDescription.tex
@@ -176,7 +176,9 @@ The third connector on the circuit board mirrors the dashboard connectors, with 
 \end{table}
 
 \section{Embedded software and completeness}
-The dashboard firmware is published at \url{https://github.com/Sgw32/DigifizReplica}. Two delivery sets are available:
+The dashboard firmware is published at the following address:
+\displayurl{https://github.com/Sgw32/DigifizReplica}
+Two delivery sets are available:
 \begin{itemize}
     \item \textbf{\ReplicaGenOne{}:} dashboard assembly, ambient and oil temperature harness, USBasp programmer, and (for remote sensors) a speed sensor harness.
     \item \textbf{\ReplicaNextLong{}:} dashboard assembly and an electronic speed sensor harness.

--- a/chapters/ReplicaMaintenance.tex
+++ b/chapters/ReplicaMaintenance.tex
@@ -26,7 +26,9 @@ This chapter applies to the classic \ReplicaGenOne{} instrument panel shown in \
 The dashboard contains a DS3231 real-time clock with a CR2032 cell. The battery typically lasts about four years. When it is depleted the clock resets at every power-up. Remove the front and/or rear cover, keep the wiring harnesses connected, and replace the coin cell. Dispose of the spent battery according to local regulations.
 
 \section{Firmware maintenance with USBasp}
-Each kit ships with a USBasp programmer lead already connected inside the housing (\autoref{fig:usbasp-cable}). Install a suitable USBasp driver (for example from \url{https://myrobot.ru/downloads/driver-usbasp-v-2.0-usb-isp-windows-7-8-10-xp.php}) before flashing. The programmer powers the dashboard when it is connected to a computer, allowing bench checks.
+Each kit ships with a USBasp programmer lead already connected inside the housing (\autoref{fig:usbasp-cable}). Install a suitable USBasp driver before flashing. For example, download it from the following address:
+\displayurl{https://myrobot.ru/downloads/driver-usbasp-v-2.0-usb-isp-windows-7-8-10-xp.php}
+The programmer powers the dashboard when it is connected to a computer, allowing bench checks.
 
 \begin{figure}[htbp]
     \centering
@@ -43,10 +45,13 @@ avrdude -c usbasp -p m2560 -e \
     -U flash:w:Digifiz.ino.mega.hex
 \end{verbatim}
 
-After a successful upload press the front touch button four to five times to initialise the memory blocks. If the blocks remain empty, repeat the flashing procedure or issue the Bluetooth command \verb|252 0| to trigger a factory reset. Ready-to-use firmware images are published at \url{https://github.com/Sgw32/DigifizReplica}.
+After a successful upload press the front touch button four to five times to initialise the memory blocks. If the blocks remain empty, repeat the flashing procedure or issue the Bluetooth command \verb|252 0| to trigger a factory reset. Ready-to-use firmware images are published at:
+\displayurl{https://github.com/Sgw32/DigifizReplica}
 
 \section{Bluetooth configuration}
-Most parameters are adjusted over Bluetooth using an Android phone and the Serial Bluetooth Terminal application (\url{https://play.google.com/store/apps/details?id=de.kai_morich.serial_bluetooth_terminal&hl=en&gl=US}). iOS devices cannot connect to the classic Bluetooth 2.0 module.
+Most parameters are adjusted over Bluetooth using an Android phone and the Serial Bluetooth Terminal application. Download it from the following link before pairing with the dashboard:
+\displayurl{https://play.google.com/store/apps/details?id=de.kai_morich.serial_bluetooth_terminal&hl=en&gl=US}
+iOS devices cannot connect to the classic Bluetooth 2.0 module.
 
 \begin{itemize}
     \item Ensure you pair with the dashboard's Bluetooth Classic interface rather than BLE-only devices.

--- a/chapters/ReplicaNextScenarios.tex
+++ b/chapters/ReplicaNextScenarios.tex
@@ -3,7 +3,9 @@
 \begin{description}
     \item[Hotspot not visible] Move closer to the vehicle and ensure it is parked in an open area. Disable mobile data, forget stale Wi-Fi profiles, and reconnect to \texttt{Digifiz\_AP} (or \texttt{PHOL-LABS2}).
     \item[404 at \texttt{192.168.4.1}] Turn off mobile data on the phone or laptop and reload the page. Captive portal detection on Android/iOS often interferes until the cellular modem is disabled.
-    \item[Firmware updates] Open the \emph{WiFi} tab, select the supplied \texttt{Digifiz.bin} file (the latest releases are published at \url{https://github.com/Sgw32/DigifizReplica/releases}), and click \emph{Upload}. The first attempt can fail; repeat the upload if necessary. Successful flashes redirect to a confirmation page. Record the odometer before updating and restore it afterwards with \verb|11 <mileage>|.
+    \item[Firmware updates] Open the \emph{WiFi} tab and select the supplied \texttt{Digifiz.bin} file. The latest releases are published at the link below.
+        \displayurl{https://github.com/Sgw32/DigifizReplica/releases}
+        Click \emph{Upload}. The first attempt can fail; repeat the upload if necessary. Successful flashes redirect to a confirmation page. Record the odometer before updating and restore it afterwards with \verb|11 <mileage>|.
     \item[Commands ignored] Refresh the browser, return to the \emph{Control} tab, and resend the command. Ensure the \emph{Process} button is pressed after entering the value.
     \item[Speed reading incorrect] Connect via Wi-Fi, drive at an indicated \SI{100}{\kilo\metre\per\hour}, note the GPS speed, then issue \verb|1 <gps_value>| (for example, \verb|1 85|) to set \texttt{PARAMETER\_SPEEDCOEFFICIENT} to the verified value.
     \item[RPM reading incorrect] Adjust \texttt{PARAMETER\_RPMCOEFFICIENT}. Older firmware uses \verb|0 <value>|; current versions use \verb|22 <value>|. Example: \verb|22 1500| halves the reading relative to \verb|22 3000|.

--- a/preamble/hacks/custom-reference-boxes.tex
+++ b/preamble/hacks/custom-reference-boxes.tex
@@ -36,6 +36,12 @@
 \NewCommandCopy{\hrefold}{\href}
 \NewCommandCopy{\urlold}{\url}
 
+\NewDocumentCommand{\displayurl}{m}{%
+    \par\noindent
+    \urlold{#1}%
+    \par
+}
+
 %% Overwrite the default link commands to use the new boxes
 \RenewDocumentCommand{\href}{O{} m m}{\hrefold{#2}{\hrefbox[#1]{#3}}}        % remote links (DOI, arXiv, etc.)
 \RenewDocumentCommand{\url}{O{} m}{\href[#1]{#2}{\nolinkurl{#2}}}            % URLs (using the new \href command)


### PR DESCRIPTION
## Summary
- add a `\displayurl` helper that prints saved hyperlinks on their own paragraph using the original `\url` implementation
- rewrite user-facing sections that reference online resources to call `\displayurl`, ensuring URLs start on a new line

## Testing
- `latexmk -pdf -interaction=nonstopmode -halt-on-error DR_DRNext_User_Manual_mk1_mk2.tex` *(fails: `latexmk` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d11646216c8323b31a8d2b9d45dc5c