### PR TITLE
Adjust title page author credit

### DIFF
--- a/frontmatter/title.tex
+++ b/frontmatter/title.tex
@@ -16,11 +16,6 @@
 
     \vspace{1.5em}
 
-    {\Huge
-        \ManualAuthor}
-
-    \vspace{1em}
-
     {\fontsize{30pt}{36pt}\selectfont \bfseries
         \ManualTitleFront \par}
 
@@ -47,6 +42,11 @@
     \ifWIP
         \small\ttfamily \textcolor{red}{(Draft - \today)} \par
     \fi
+
+    \vfill
+
+    {\ifFANCY\sffamily\Large\else\Large\fi
+        \ManualAuthorFooter}
 \end{center}
 
 \newpage

--- a/preamble/data.tex
+++ b/preamble/data.tex
@@ -18,9 +18,11 @@
 }
 
 %% Author credited for the manual
-\newcommand*{\ManualAuthor}{Digifiz Replica Project Team - PHOL LABS Kft}
+\newcommand*{\ManualAuthor}{PHOL LABS Kft}
 %% Plaintext version for PDF metadata, uncomment if needed (defaults to \ManualAuthor)
-\newcommand*{\ManualAuthorPlaintext}{Digifiz Replica Project Team - PHOL LABS Kft}
+\newcommand*{\ManualAuthorPlaintext}{PHOL LABS Kft}
+%% Layout variant displayed in the title page footer
+\newcommand*{\ManualAuthorFooter}{PHOL \\ LABS Kft}
 
 %% Year when the manual is released
 \newcommand*{\YearReleased}{\the\year}


### PR DESCRIPTION
## Summary
- move the author credit on the title page into a footer block and keep the main heading layout intact
- update the manual author metadata to "PHOL LABS Kft" and add a footer-specific variant for the title page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d25dcea9108323a4cce037d0b108ca