### PR TITLE
Rename Scirocco harness section and adjust plug tables

### DIFF
--- a/chapters/ProductDescription.tex
+++ b/chapters/ProductDescription.tex
@@ -114,10 +114,10 @@ Single-connector dashboards use the mapping shown in \autoref{fig:single-connect
     \label{fig:single-connector}
 \end{figure}
 
-\subsection{Scirocco prospective harness}
-The prospective Scirocco harness uses two plugs. Their functions are summarised below.
+\subsection{Scirocco/Passat prospective harness}
+The prospective Scirocco/Passat harness uses two plugs. Their functions are summarised below.
 
-\paragraph{5-pin plug}
+\noindent\textbf{5-pin plug}
 {\scriptsize
 \begin{tblr}{
     colspec={Q[l,2.6cm] X[l]},
@@ -131,7 +131,7 @@ The prospective Scirocco harness uses two plugs. Their functions are summarised 
 5~(SPERRE) & Starter interlock contact from the selector. Closed in park or neutral to permit engine cranking. \\
 \end{tblr}}
 
-\paragraph{14-pin plug}
+\noindent\textbf{14-pin plug}
 {\scriptsize
 \begin{tblr}{
     colspec={Q[l,2.6cm] X[l]},


### PR DESCRIPTION
## Summary
- rename the Scirocco prospective harness subsection to Scirocco/Passat prospective harness
- update the harness description to reference Scirocco/Passat
- display the 5-pin and 14-pin plug tables directly beneath their headings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2601e690c832391356fc86003e2e3