### PR TITLE
Document auxiliary expansion connectors

### DIFF
--- a/chapters/ProductDescription.tex
+++ b/chapters/ProductDescription.tex
@@ -208,6 +208,15 @@ The third connector on the circuit board mirrors the dashboard connectors, with 
     \end{tblr}}
 \end{table}
 
+\subsection{Auxiliary expansion connectors}
+Three supplementary four-pin headers are fitted to the main board to simplify harness upgrades and service work:
+\begin{itemize}
+    \item \textbf{Expansion analog signals:} provides a dedicated breakout for additional analog inputs when integrating custom sensors.
+    \item \textbf{MFA mirror:} duplicates the standard \textsc{MFA} connector to support parallel tapping of the trip computer signals.
+    \item \textbf{Analog duplicates:} repeats the oil temperature, ambient temperature, and brake indicator inputs so these circuits can be routed to external logging or monitoring modules.
+\end{itemize}
+All three use the \mbox{KF2510-4p} mating connector, which is not supplied with the dashboard kit and must be sourced separately if needed.
+
 \section{Embedded software and completeness}
 The dashboard firmware is published at the following address:
 \displayurl{https://github.com/Sgw32/DigifizReplica}


### PR DESCRIPTION
## Summary
- describe the three supplementary four-pin headers available on the main board
- clarify the purpose of each header for expansion analog inputs, MFA duplication, and duplicated instrument inputs
- note that the KF2510-4p mating connector is required and not included in the kit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6538111e8832399f63657bfe3d2e3