### PR TITLE
Document Digifiz Next dashboard Settings and Colors tabs

### DIFF
--- a/chapters/ReplicaNextMaintenance.tex
+++ b/chapters/ReplicaNextMaintenance.tex
@@ -20,7 +20,7 @@ Configuration, data collection, and firmware management are performed through th
 \begin{itemize}
     \item Connect to the dashboard's Wi-Fi access point. Disable mobile data and join \texttt{Digifiz\_AP} (password \texttt{87654321}); some revisions advertise \texttt{PHOL-LABS2} with the same password.
     \item The default IP address is \texttt{192.168.4.1}. If the dashboard is configured to join another network, scan the subnet for an address ending in \texttt{.32} using an IP tools application.
-    \item The portal contains three tabs: \emph{WiFi}, \emph{Control}, and \emph{About} (\autoref{fig:next-control-tabs}). The Wi-Fi tab configures network settings and handles firmware uploads; the Control tab adjusts dashboard parameters; the About tab lists author information.
+    \item The portal contains five tabs: \emph{WiFi}, \emph{Control}, \emph{Settings}, \emph{Colors}, and \emph{About} (\autoref{fig:next-control-tabs}). The Wi-Fi tab configures network settings and handles firmware uploads; the Control tab adjusts dashboard parameters; the Settings tab provides a structured editor for all firmware parameters; the Colors tab manages multi-segment colour schemes; the About tab lists author information.
 \end{itemize}
 
 \begin{figure}[htbp]
@@ -154,3 +154,31 @@ To read a parameter, add 128 to the command number (for example, \verb|129 0| re
 
 \section{Service commands}
 Recent firmware revisions accept human-readable parameter names, for example \verb|PARAMETER_RPMCOEFFICIENT 3000|. The diagnostic command \verb|adc 0| prints raw ADC readings for sensor troubleshooting. Firmware updates add visual colour controls, so update regularly through the \emph{WiFi} tab to access the latest features.
+
+\section{Settings tab parameter editor}
+The \emph{Settings} tab mirrors the parameter list in \autoref{tbl:next-commands} and \autoref{tbl:next-defaults} while adding metadata about ranges, descriptions, and data types.
+Use it whenever you prefer a graphical workflow instead of typing command numbers.
+
+\begin{enumerate}
+    \item Press \emph{Load Parameters} to fetch the live values from the dashboard. The browser displays each item with its name, current value, tooltip, and type.
+    \item For numeric entries, type the desired value inside the \emph{New Value} column. The interface enforces the permissible range shown in the \emph{Min} and \emph{Max} columns. Boolean parameters appear as checkboxes.
+    \item Click \emph{Set} to submit the change instantly. The table refreshes to confirm the updated value.
+    \item Repeat the process for every parameter you want to adjust. When finished, return to the \emph{Control} tab and press \emph{Save parameters} to write the configuration to non-volatile memory.
+\end{enumerate}
+
+The colour workflow requires that you enable the firmware flag responsible for custom palettes before moving to the \emph{Colors} tab.
+Locate the boolean entry labelled ``Custom colour scheme'' (published as \verb|PARAMETER_CUSTOM_COLORSCHEME_ENABLE| in the parameter list), tick the checkbox, and press \emph{Set}. The dashboard will reject bespoke segment edits until this flag is turned on.
+
+\section{Custom colour schemes}
+The \emph{Colors} tab introduces a segment-based editor for the WS2812 LED backlight. Each row describes a range end point, the functional area it corresponds to, and the colour or base colour inheritance.
+
+\begin{enumerate}
+    \item Press \emph{Load Scheme} to read the active mapping. Use \emph{Add Segment}, or the inline ``+\textuparrow{}'' and ``+\textdownarrow{}'' controls, to insert new ranges. The drop-down menus select the instrument function, and the base-colour selector lets you reuse the main or back colours instead of specifying a fixed RGB value.
+    \item Click the colour picker to fine-tune the RGB tone for segments that are set to ``Custom''. The editor reports component values in real time.
+    \item Use the reorder arrows to match the physical LED sequence (segments must remain in ascending order). Delete redundant rows with the ``\texttimes{}'' button.
+    \item When the table reflects the desired layout, press \emph{Set Scheme}. The browser iterates through the rows and pushes each segment to the dashboard.
+    \item Immediately switch to the \emph{Control} tab and press \emph{Save parameters}. This step is mandatory---the firmware caches the uploaded segments in RAM and discards them after a reboot if they are not saved.
+    \item Optionally export the JSON representation via \emph{Export to File} for backups, or import a previously saved file with \emph{Import from File}. The \emph{Reset Scheme} button restores the factory layout after confirmation.
+\end{enumerate}
+
+If you later disable the custom colour scheme flag in the \emph{Settings} tab, the dashboard falls back to the classic single-colour mode driven by \verb|PARAMETER_MAINCOLOR_R/G/B|.

--- a/chapters_fr/ReplicaNextMaintenance.tex
+++ b/chapters_fr/ReplicaNextMaintenance.tex
@@ -20,7 +20,7 @@ La configuration, la collecte de données et la gestion du micrologiciel s'effec
 \begin{itemize}
     \item Connectez-vous au point d'accès Wi-Fi du tableau. Désactivez les données mobiles et rejoignez \texttt{Digifiz\_AP} (mot de passe \texttt{87654321}); certaines révisions annoncent \texttt{PHOL-LABS2} avec le même mot de passe.
     \item L'adresse IP par défaut est \texttt{192.168.4.1}. Si le tableau est configuré pour rejoindre un autre réseau, analysez le sous-réseau à la recherche d'une adresse se terminant par \texttt{.32} à l'aide d'un utilitaire IP.
-    \item Le portail comporte trois onglets~: \emph{WiFi}, \emph{Control} et \emph{About} (\autoref{fig:next-control-tabs}). L'onglet WiFi gère les paramètres réseau et les mises à jour de micrologiciel ; l'onglet Control ajuste les paramètres du tableau ; l'onglet About récapitule les informations sur les auteurs.
+    \item Le portail comporte cinq onglets~: \emph{WiFi}, \emph{Control}, \emph{Settings}, \emph{Colors} et \emph{About} (\autoref{fig:next-control-tabs}). L'onglet WiFi gère les paramètres réseau et les mises à jour de micrologiciel ; l'onglet Control ajuste les paramètres du tableau ; l'onglet Settings propose un éditeur structuré de tous les paramètres du micrologiciel ; l'onglet Colors pilote les jeux de couleurs multi-segments ; l'onglet About récapitule les informations sur les auteurs.
 \end{itemize}
 
 \begin{figure}[htbp]
@@ -161,3 +161,31 @@ Les commandes 31 à 33 fixent les composantes RVB de la couleur d'interface.
 Les versions récentes du micrologiciel acceptent les noms de paramètres lisibles, par exemple \verb|PARAMETER_RPMCOEFFICIENT 3000|.
 La commande de diagnostic \verb|adc 0| affiche les mesures ADC brutes pour le dépannage des capteurs.
 Les mises à jour de micrologiciel ajoutent des contrôles visuels de couleur ; mettez régulièrement à jour via l'onglet \emph{WiFi} pour profiter des dernières fonctionnalités.
+
+\section{Éditeur de paramètres (onglet Settings)}
+L'onglet \emph{Settings} reprend la liste de \autoref{tbl:next-commands} et \autoref{tbl:next-defaults} en y ajoutant les plages autorisées, le type de donnée et des infobulles.
+Il constitue une alternative graphique à la saisie de commandes numériques.
+
+\begin{enumerate}
+    \item Cliquez sur \emph{Load Parameters} pour charger les valeurs en direct depuis le tableau. Chaque ligne affiche le nom du paramètre, sa valeur courante, une description et son type.
+    \item Pour les champs numériques, saisissez la valeur souhaitée dans la colonne \emph{New Value}. L'interface impose la plage indiquée dans les colonnes \emph{Min} et \emph{Max}. Les paramètres booléens sont présentés sous forme de cases à cocher.
+    \item Appuyez sur \emph{Set} pour envoyer immédiatement la modification. Le tableau se recharge afin de confirmer la mise à jour.
+    \item Répétez l'opération pour chaque paramètre à ajuster. Une fois terminé, revenez dans l'onglet \emph{Control} et appuyez sur \emph{Save parameters} afin d'écrire la configuration en mémoire non volatile.
+\end{enumerate}
+
+Avant d'utiliser l'onglet \emph{Colors}, activez l'indicateur micrologiciel dédié aux palettes personnalisées.
+Repérez la case booléenne intitulée «~Custom colour scheme~» (exposée sous la forme \verb|PARAMETER_CUSTOM_COLORSCHEME_ENABLE| dans la liste) ; cochez-la puis validez avec \emph{Set}. Le tableau refusera toute modification de segments tant que ce drapeau reste inactif.
+
+\section{Jeux de couleurs personnalisés}
+L'onglet \emph{Colors} fournit un éditeur par segments pour le rétroéclairage WS2812. Chaque ligne définit une fin de plage, la zone fonctionnelle concernée et la couleur (fixe ou héritée).
+
+\begin{enumerate}
+    \item Cliquez sur \emph{Load Scheme} pour lire la cartographie active. Utilisez \emph{Add Segment} ou les contrôles «~+\textuparrow{}~» et «~+\textdownarrow{}~» pour insérer de nouvelles plages. Les listes déroulantes associent la fonction instrument, tandis que le sélecteur de base permet de réemployer la couleur principale ou d'arrière-plan plutôt qu'un RVB fixe.
+    \item Ajustez la teinte via le sélecteur de couleur pour les segments configurés en «~Custom~». L'éditeur affiche en direct les composantes.
+    \item Réordonnez les lignes à l'aide des flèches afin de respecter l'ordre physique des LED (les segments doivent rester croissants). Supprimez les entrées inutiles avec le bouton «~\texttimes{}~».
+    \item Lorsque la table reflète le rendu souhaité, appuyez sur \emph{Set Scheme}. Le navigateur parcourt chaque segment et l'envoie au tableau.
+    \item Passez immédiatement dans l'onglet \emph{Control} et cliquez sur \emph{Save parameters}. Cette étape est obligatoire~: sans sauvegarde, le micrologiciel conserve les segments en RAM et les perdra après redémarrage.
+    \item Exportez éventuellement la représentation JSON via \emph{Export to File} pour constituer une sauvegarde, ou importez un fichier existant avec \emph{Import from File}. Le bouton \emph{Reset Scheme} restaure la configuration d'usine après confirmation.
+\end{enumerate}
+
+Si vous désactivez ultérieurement le drapeau de jeu de couleurs personnalisé dans l'onglet \emph{Settings}, le tableau revient au mode monochrome classique piloté par \verb|PARAMETER_MAINCOLOR_R/G/B|.


### PR DESCRIPTION
## Summary
- update the Wi-Fi control portal description to cover the Settings and Colors tabs
- add an English section detailing how to edit parameters in the Settings tab and manage custom colour schemes
- add the corresponding French documentation for Settings and Colors, including the prerequisites for custom schemes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3026af85c8323bf01af369d28a8c6