### PR TITLE
Update enum label styles in typesetting

### DIFF
--- a/preamble/general/typesetting.tex
+++ b/preamble/general/typesetting.tex
@@ -33,4 +33,8 @@
 \usepackage[alwaysadjust,neverdecrease]{paralist}   % improved enumerate and itemize
 \setdefaultleftmargin{1.87em}{1.7em}{1.5em}{1em}{1em}{1em}
 \setdefaultitem{$\bullet$}{\textbullet}{\textasteriskcentered}{\textperiodcentered}
-\setdefaultenum{\bfseries (1)}{\bfseries (a)}{\bfseries (i)}{A.}
+\setdefaultenum{\bfseries 1.}{\bfseries a.}{\bfseries i.}{A.}
+\renewcommand{\labelenumi}{\bfseries\arabic{enumi}.}
+\renewcommand{\labelenumii}{\bfseries\alph{enumii}.}
+\renewcommand{\labelenumiii}{\bfseries\roman{enumiii}.}
+\renewcommand{\labelenumiv}{\bfseries\Alph{enumiv}.}


### PR DESCRIPTION
### Motivation
- Change default enumerate appearance to use bold numeric/alpha/roman labels with trailing periods and explicit label commands for consistent formatting.

### Description
- Replace `\setdefaultenum{\bfseries (1)}{\bfseries (a)}{\bfseries (i)}{A.}` with `\setdefaultenum{\bfseries 1.}{\bfseries a.}{\bfseries i.}{A.}` and add `\renewcommand{\labelenumi}{\bfseries\arabic{enumi}.}`, `\renewcommand{\labelenumii}{\bfseries\alph{enumii}.}`, `\renewcommand{\labelenumiii}{\bfseries\roman{enumiii}.}` and `\renewcommand{\labelenumiv}{\bfseries\Alph{enumiv}.}` in `preamble/general/typesetting.tex`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698249bed1408323a7b7e0d4a451f715)